### PR TITLE
feat: add --user option to select account for token retrieval

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	host     string
+	user     string
 	insecure bool
 	cenvs    []string
 )
@@ -54,7 +55,7 @@ var rootCmd = &cobra.Command{
 		os.Setenv("GH_HOST", host)
 		token, v3ep, _, v4ep, host, _, _ := factory.GetAllDetected()
 		if !insecure {
-			sectoken, err := tokenFromSecureStorage(host)
+			sectoken, err := tokenFromSecureStorage(host, user)
 			if err != nil {
 				return fmt.Errorf("failed to get credentials stored in secure storage for %s: %w", host, err)
 			}
@@ -130,11 +131,12 @@ func Execute() {
 func init() {
 	rootCmd.Flags().BoolP("help", "", false, "help for gh-do") // disable `-h` for help
 	rootCmd.Flags().StringVarP(&host, "hostname", "h", "", "the hostname of the GitHub instance to do")
+	rootCmd.Flags().StringVarP(&user, "user", "u", "", "the account to output the token for")
 	rootCmd.Flags().BoolVarP(&insecure, "insecure", "", false, "use insecure credentials")
 	rootCmd.Flags().StringSliceVarP(&cenvs, "credential-env-key", "e", []string{}, "set credential to specified env key")
 }
 
-func tokenFromSecureStorage(host string) (string, error) {
+func tokenFromSecureStorage(host, user string) (string, error) {
 	var err error
 	gh := os.Getenv("GH_PATH")
 	if gh == "" {
@@ -145,7 +147,11 @@ func tokenFromSecureStorage(host string) (string, error) {
 	}
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command(gh, "auth", "token", "--secure-storage", "--hostname", host)
+	args := []string{"auth", "token", "--secure-storage", "--hostname", host}
+	if user != "" {
+		args = append(args, "--user", user)
+	}
+	cmd := exec.Command(gh, args...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTokenFromSecureStorage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script is not supported on windows")
+	}
+	tests := []struct {
+		name     string
+		host     string
+		user     string
+		wantArgs []string
+	}{
+		{
+			name:     "without user",
+			host:     "github.com",
+			user:     "",
+			wantArgs: []string{"auth", "token", "--secure-storage", "--hostname", "github.com"},
+		},
+		{
+			name:     "with user",
+			host:     "github.com",
+			user:     "alice",
+			wantArgs: []string{"auth", "token", "--secure-storage", "--hostname", "github.com", "--user", "alice"},
+		},
+		{
+			name:     "with enterprise host and user",
+			host:     "enterprise.internal",
+			user:     "bob",
+			wantArgs: []string{"auth", "token", "--secure-storage", "--hostname", "enterprise.internal", "--user", "bob"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsFile := filepath.Join(dir, "args")
+			scriptPath := filepath.Join(dir, "gh")
+			script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\necho fake-token\n"
+			if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GH_PATH", scriptPath)
+
+			got, err := tokenFromSecureStorage(tt.host, tt.user)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "fake-token" {
+				t.Errorf("token = %q, want %q", got, "fake-token")
+			}
+
+			b, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("failed to read args: %v", err)
+			}
+			gotArgs := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
+			if !slices.Equal(gotArgs, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestTokenFromSecureStorageError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script is not supported on windows")
+	}
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\necho 'boom' >&2\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_PATH", scriptPath)
+
+	_, err := tokenFromSecureStorage("github.com", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "boom" {
+		t.Errorf("error = %q, want %q", err.Error(), "boom")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--user` (`-u`) option that is passed through to `gh auth token --user`, so users with multiple accounts on the same host (e.g. github.com) can choose which credentials `gh-do` resolves.
- Unit tests for `tokenFromSecureStorage` covering with/without `--user` and the enterprise host case, plus error propagation.

## Use case

When working with multiple github.com accounts, you can switch credentials per repository by combining `gh-do` with `gh auth git-credential`:

```console
$ gh do --user example1 -- gh auth git-credential fill
```

This makes it easy to use different accounts for different repositories without reconfiguring global `gh` state.

cc @k1LoW 

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/...`
- [x] Manual: `gh do --user <account> -- gh auth git-credential fill` returns the expected account's token